### PR TITLE
Fixed reference to fuge-system project

### DIFF
--- a/doc/demo-fuge.md
+++ b/doc/demo-fuge.md
@@ -16,7 +16,7 @@ Install these before getting started.
 You can clone these branches directly - for example:
 
 ```sh
-$ git clone https://github.com/concorda/concorda-fuge
+$ git clone https://github.com/concorda/concorda-system
 ```
 
 You need to install all dependencies:


### PR DESCRIPTION
Previously in the docs the former `concorda-fuge` project was reference while now all the fuge configurations are available in `concorda-system`
